### PR TITLE
Add: 各ページごとにウィンドウタイトルを設定

### DIFF
--- a/frontend/src/app/employee/[id]/page.tsx
+++ b/frontend/src/app/employee/[id]/page.tsx
@@ -1,11 +1,13 @@
-import { EmployeeDetailsContainer } from "@/components/EmployeeDetailsContainer";
+// app/employees/[id]/page.tsx
 import { GlobalContainer } from "@/components/GlobalContainer";
-import { Suspense } from 'react';
+import { EmployeeDetailsContainer } from "@/components/EmployeeDetailsContainer";
+import { DynamicTitle } from "@/components/DynamicTitle";
+import { Suspense } from "react";
 
 export default function EmployeePage() {
   return (
     <GlobalContainer>
-      { /* Mark EmployeeDetailsContainer as CSR */ }
+      <DynamicTitle />
       <Suspense>
         <EmployeeDetailsContainer />
       </Suspense>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -25,6 +25,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ja">
+      <head>
+        {/* ✅ この1行がクライアントサイドのtitle変更を有効化する */}
+        <meta charSet="utf-8" />
+      </head>
       <body className={`${geistSans.variable} ${geistMono.variable}`}>
         <AppRouterCacheProvider>{children}</AppRouterCacheProvider>
       </body>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,9 +1,11 @@
 import { SearchEmployees } from "../components/SearchEmployees";
 import { GlobalContainer } from "@/components/GlobalContainer";
+import { DynamicTitle } from "@/components/DynamicTitle";
 
 export default function Home() {
   return (
     <GlobalContainer>
+      <DynamicTitle />
       <SearchEmployees />
     </GlobalContainer>
   );

--- a/frontend/src/components/DynamicTitle.tsx
+++ b/frontend/src/components/DynamicTitle.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+import { PAGE_TITLES } from "@/components/pageTitles";
+
+function resolveTitle(pathname: string): string {
+  if (pathname === "/") {
+    return PAGE_TITLES["/"];
+  }
+
+  // 明示的に対応：/employee/[id]
+  if (/^\/employee\/[^/]+$/.test(pathname)) {
+    return PAGE_TITLES["/employee/[id]"];
+  }
+
+  // fallback
+  return "タレントマネジメントシステム";
+}
+
+export function DynamicTitle() {
+  const pathname = usePathname();
+  const title = resolveTitle(pathname);
+
+  useEffect(() => {
+    document.title = title;
+  }, [title]);
+
+  return null;
+}

--- a/frontend/src/components/pageTitles.ts
+++ b/frontend/src/components/pageTitles.ts
@@ -1,0 +1,7 @@
+// src/constants/pageTitles.ts
+
+export const PAGE_TITLES: Record<string, string> = {
+    "/": "タレントマネジメントシステム - 社員検索",
+    "/employee/[id]": "タレントマネジメントシステム - 社員詳細",
+    // 必要に応じて追加
+};


### PR DESCRIPTION
## 概要
ウィンドウタイトルへのページ名の表示

## 詳細
ウィンドウタイトルに、「社員検索」や「社員詳細」など、  
ユーザーが「自分が今どのページにいるのか」を明示的に表示するようにしました。

現状の実装では各ページごとに個別にタイトル文言を設定していますが、  
将来的にはページ遷移時のコールバック関数などを利用して  
「`タレントマネジメントシステム - {ページ名}`」のように  
`-`（ハイフン）以降を自動で切り替える仕組みを導入したいと考えています。

## 生成AIの利用について
今回の修正にあたっては、ChatGPT-4o を使用しました。  
treeコマンドでディレクトリ構成を渡し、既存の設計を崩さずに実装するよう指示しています。

- 使用モデル: ChatGPT-4o  
- チャット履歴: [https://chatgpt.com/share/6868aa40-3ba8-8013-a61f-7dc0f88e3eeb](https://chatgpt.com/share/6868aa40-3ba8-8013-a61f-7dc0f88e3eeb)