### PR TITLE
Task 2:社員詳細画面に、「検索画面に戻る」リンクを追加する#2

### DIFF
--- a/frontend/src/components/EmployeeDetails.tsx
+++ b/frontend/src/components/EmployeeDetails.tsx
@@ -2,6 +2,9 @@ import PersonIcon from "@mui/icons-material/Person";
 import { Avatar, Box, Paper, Tab, Tabs, Typography } from "@mui/material";
 import { Employee } from "../models/Employee";
 import { useCallback, useState } from "react";
+import Link from "next/link";
+import { Button } from "@mui/material"; 
+import ArrowBackIcon from "@mui/icons-material/ArrowBack"; // 戻るアイコン
 
 const tabPanelValue = {
   basicInfo: "基本情報",
@@ -52,6 +55,15 @@ export function EmployeeDetails(prop: EmployeeDetailsProps) {
         alignItems="flex-start"
         gap={1}
       >
+          <Button
+          href="/"
+          variant="outlined"
+          startIcon={<ArrowBackIcon />} 
+          color="primary"
+          >
+            検索画面に戻る
+          </Button>
+        
         <Box
           display="flex"
           flexDirection="row"


### PR DESCRIPTION
### 概要
「検索画面に戻る」リンクを実装しました。

### 詳細
WHI-intern-2025/frontend/src/components/EmployeeDetails.tsx
に検索画面に戻るためのボタンを追加しました。
muiを利用してボタンのデザインを行っています。