### PR TITLE
Task3: グローバルヘッダに、「社員検索」や「社員詳細」など、「自分が今どのページにいるのか」を表示する#10

### DIFF
--- a/frontend/src/app/employee/[id]/page.tsx
+++ b/frontend/src/app/employee/[id]/page.tsx
@@ -6,7 +6,7 @@ import { Suspense } from "react";
 
 export default function EmployeePage() {
   return (
-    <GlobalContainer>
+    <GlobalContainer pageTitle="社員詳細">
       <DynamicTitle />
       <Suspense>
         <EmployeeDetailsContainer />

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -4,7 +4,7 @@ import { DynamicTitle } from "@/components/DynamicTitle";
 
 export default function Home() {
   return (
-    <GlobalContainer>
+    <GlobalContainer pageTitle="社員検索">
       <DynamicTitle />
       <SearchEmployees />
     </GlobalContainer>

--- a/frontend/src/components/GlobalContainer.tsx
+++ b/frontend/src/components/GlobalContainer.tsx
@@ -3,13 +3,19 @@ import { VerticalSpacer } from "../components/VerticalSpacer";
 import { GlobalHeader } from "../components/GlobalHeader";
 import { GlobalFooter } from "../components/GlobalFooter";
 
-export function GlobalContainer({ children }: { children?: React.ReactNode }) {
+export function GlobalContainer({
+  children,
+  pageTitle,
+}: {
+  children?: React.ReactNode;
+  pageTitle?: string;
+}){
   return (
     <Container
       sx={{ display: "flex", flexDirection: "column", minHeight: "100vh" }}
     >
       <header>
-        <GlobalHeader title={"タレントマネジメントシステム"} />
+        <GlobalHeader title={`タレントマネジメントシステム${pageTitle ? "　" + pageTitle : ""}`} />
       </header>
 
       <VerticalSpacer height={32} />


### PR DESCRIPTION
### 概要
グローバルヘッダに、「社員検索」や「社員詳細」など、「自分が今どのページにいるのか」を表示する

###詳細
<GlobalContainer pageTitle="社員詳細">のようにGlobalContainerを呼び出す際にpropsでタイトルの一部を渡してそれを追加で表示しています。

### 生成AIの利用について
どのようなアイディアで実装するかは生成AIに教えてもらいました。モデルはGPT-4oで会話履歴は添付の通りです。
https://chatgpt.com/s/t_6868be41b7448191ba6a7b8e627fe3db