### PR TITLE
Add: 社員の属性から検索できるようにした

### DIFF
--- a/backend-ts/src/employee/EmployeeDatabaseInMemory.ts
+++ b/backend-ts/src/employee/EmployeeDatabaseInMemory.ts
@@ -27,7 +27,11 @@ export class EmployeeDatabaseInMemory implements EmployeeDatabase {
 
         return employees.filter((employee) => {
             const normalizedName = normalizeName(employee.name);
-            return normalizedName.includes(normalizedKeyword);
+            const ageString = employee.age.toString();
+            return (
+                normalizedName.includes(normalizedKeyword) ||
+                ageString.includes(filterText)
+            );
         });
     }
 }


### PR DESCRIPTION
## 概要  
社員情報検索において、氏名だけでなく**年齢の部分一致検索**にも対応しました。

---

## 詳細  
- 入力された検索語（例：`28`）に対して、`28歳` の社員が検索対象となります。
<img width="719" alt="スクリーンショット 2025-07-05 16 14 09" src="https://github.com/user-attachments/assets/3bc33ea9-7711-4948-b1a5-549e6c9ed1a5" />


---

## 生成AIの利用について  

- **ChatGPT-4o（OpenAI）** に以下の内容を相談した上で実装しました。  
    - **会話履歴**：https://chatgpt.com/share/6868d073-c50c-8013-81a5-7544b8fb36b0